### PR TITLE
fix: add ESET certs to download pre-trained model if not cached

### DIFF
--- a/Dockerfiles/gpu-310.Dockerfile
+++ b/Dockerfiles/gpu-310.Dockerfile
@@ -174,6 +174,10 @@ ENV WORKDIR /marie
 COPY --from=build-image /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
 
+# Add ESET certs to download models from fairseq
+RUN pip3 install get_cert
+RUN get_cert "https://dl.fbaipublicfiles.com" >> /opt/venv/lib/python3.10/site-packages/certifi/cacert.pem
+
 # Install and initialize MARIE-AI, copy all necessary files
 # copy will almost always invalididate the cache
 COPY ./im-policy.xml /etc/ImageMagick-6/policy.xml


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
<!---https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword--->

- resolves #99 
- ...
- ...

- ...
- ...
- [ ] check and update documentation. See [guide](https://github.com/marieai/marie-ai/blob/main/CONTRIBUTING.md#-contributing-documentation) and ask the team.
