### PR TITLE
Matched Section Bleed & Faiss Annotator multi block match

### DIFF
--- a/marie/extract/annotators/faiss_hybrid_annotator.py
+++ b/marie/extract/annotators/faiss_hybrid_annotator.py
@@ -74,6 +74,8 @@ class FaissHybridAnnotator(DocumentAnnotator):
         self.top_k_candidates = annotator_conf.get('top_k_candidates', 3)
         self.fuzzy_threshold = annotator_conf.get('fuzzy_threshold', 0.8)
         self.embedding_threshold = annotator_conf.get('embedding_threshold', 0.85)
+        self.block_threshold = annotator_conf.get('block_threshold', 0.75)
+        self.max_blocks = annotator_conf.get('max_blocks')
         self.fuzzy_weight = annotator_conf.get('fuzzy_weight', 0.3)
         self.embedding_weight = annotator_conf.get('embedding_weight', 0.7)
         self.min_final_score = annotator_conf.get('min_final_score', 0.7)
@@ -330,9 +332,10 @@ class FaissHybridAnnotator(DocumentAnnotator):
                 concept_view=True,
                 concepts=self.concepts(),
                 drift_monitor=True,
-                good_threshold=0.75,
+                good_threshold=self.block_threshold,
                 enforce_good_only=True,
                 annotate_good_flag=True,
+                max_blocks=self.max_blocks,
             )
 
             allowed = set()

--- a/marie/extract/results/span_util.py
+++ b/marie/extract/results/span_util.py
@@ -130,10 +130,11 @@ def pagespan_from_start_stop(
         span = Span(page=i, h=page_h, msg=msg)
         if i == sp:
             span.y = start_y
-            if (
-                sp == stop.page
-            ):  # when the start and stop points are the same, the height of the span should be 1
-                span.h = stop_y - start_y + 1
+            if start_y == stop_y:
+                # when the start and stop points are the same, the height of the span should be 1
+                span.h = 1
+            elif sp == stop.page:
+                span.h = stop_y - start_y
             else:
                 span.h = page_h - start_y
         elif i == ep:


### PR DESCRIPTION
<!---Decomposing the complex issue into subtasks can help you build it step-by-step. Thanks for your pull request! :rocket: --->
<!---We know that dev life is hectic, but **please provide a (brief) description** of what your PR does, and how it does it. **Otherwise, your PR cannot be reviewed!** --->
<!---This policy was agreed upon in a past company retro, and makes everyone's life a little easier. Thanks for your collaboration!--->

**Goals:**
- Fixes matched section bleed where first line of next section bleeds into current section
- Fixes faiss hybrid annotator only matching one claim per page
- Adds optional configs for faiss hybrid annotator: 
  - block_threshold 
  - max_blocks 
